### PR TITLE
Done: 랭킹 리스트 출력 - api 호출 작업 끗, 실제 데이터가 아닌 가짜 데이터로 작업

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -46,10 +46,10 @@ const Header: React.FC<IProps> = ({
       <div className="user-info">
         {isAuthenticated ? (
           <div className="logged">
-            <a href={`https://github.com/${user.username}`} target="blank">
-              {user.username}
+            <a href={`https://github.com/${user?.username}`} target="blank">
+              {user?.username}
             </a>
-            <img src={user.avatarUrl} alt={user.username} />
+            <img src={user?.avatarUrl} alt={user?.username} />
             <Link href="/logout">
               <a>로그아웃</a>
             </Link>

--- a/components/PageMain.tsx
+++ b/components/PageMain.tsx
@@ -1,12 +1,35 @@
 import * as React from "react";
 import styled from "styled-components";
-interface IProps {}
-const PageMain: React.FC<IProps> = () => {
-  return <MainContainer>Welcome</MainContainer>;
+import Rank from "./Rank";
+interface IProps {
+  ranks: any[];
+}
+export interface IRank {
+  username: string;
+  email: string;
+  avatarUrl: string;
+  rank: number;
+  commitDays: number;
+}
+
+const PageMain: React.FC<IProps> = ({ ranks }) => {
+  return (
+    <MainContainer>
+      {ranks.map((rank) => (
+        <Rank key={rank.username + "-key"} info={rank} />
+      ))}
+    </MainContainer>
+  );
 };
 
 const MainContainer = styled.main`
-  padding: 50px 0;
+  padding: 60px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
+  background-color: #e67e22;
+  height: 100vh;
 `;
 
 export default PageMain;

--- a/components/Rank.tsx
+++ b/components/Rank.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import styled from "styled-components";
+import { IRank } from "./PageMain";
+
+interface IProps {
+  info: IRank;
+}
+
+const Rank: React.FC<IProps> = ({ info }) => {
+  return (
+    <RankContainer>
+      <h4>{info.rank}위</h4>
+      <div>
+        <img src={info.avatarUrl} alt={info.username} />
+        <a href={`https://github.com/${info.username}`} target="blank">
+          {info.username}
+        </a>
+      </div>
+      <h5>{info.commitDays}일 동안 커밋중</h5>
+    </RankContainer>
+  );
+};
+
+const RankContainer = styled.div`
+  width: 500px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 20px;
+  border-radius: 10px;
+  background-color: #ecf0f1;
+
+  img {
+    border-radius: 15px;
+    width: 20px;
+    height: 20px;
+  }
+`;
+
+export default Rank;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,8 +5,8 @@ import "styles/reset.css";
 import { ThemeProvider } from "styled-components";
 
 export interface IDefaultProps {
-  isAuthenticated: boolean;
-  user: IUser;
+  isAuthenticated?: boolean;
+  user?: IUser;
 }
 
 interface IUser {
@@ -47,9 +47,14 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
   const appProps = await App.getInitialProps(appContext);
   const user: IUser = (appContext.ctx.req as any)?.user;
 
+  const componentProps = await appContext.Component.getInitialProps?.(
+    appContext.ctx,
+  );
+  console.log("[MyApp]", componentProps);
   appProps.pageProps = {
     isAuthenticated: user ? true : false,
     user,
+    ...componentProps,
   };
 
   return { ...appProps };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,16 +1,28 @@
 import BasicLayout from "components/BasicLayout";
 import PageMain from "components/PageMain";
 import { IDefaultProps } from "./_app";
+import { NextPage, NextPageContext } from "next";
+import axios from "axios";
 
 /** @format */
-interface IProps extends IDefaultProps {}
+interface IProps extends IDefaultProps {
+  ranksData: any[];
+}
 
-const Index: React.FC<IProps> = ({ isAuthenticated, user }) => {
+const Index: NextPage<IProps> = ({ isAuthenticated, user, ranksData }) => {
+  console.log(ranksData);
   return (
     <BasicLayout isAuthenticated={isAuthenticated} user={user}>
-      <PageMain />
+      <PageMain ranks={ranksData} />
     </BasicLayout>
   );
 };
 
+Index.getInitialProps = async (ctx: NextPageContext) => {
+  const ranks = await axios.get("http://localhost:3000/api/ranks?next=1");
+  const ranksData = ranks.status === 200 ? ranks.data : [];
+
+  console.log(">>><<<", ranksData);
+  return { ranksData };
+};
 export default Index;

--- a/server/controllers/apiController.ts
+++ b/server/controllers/apiController.ts
@@ -1,0 +1,102 @@
+import { IUser } from "../models/User";
+
+const mockupData: Partial<IUser>[] = [
+  {
+    username: "max",
+    email: "max@test.io",
+    avatarUrl:
+      "https://avatars0.githubusercontent.com/u/37009133?s=400&u=3998f5edfd907a527fbd8cac4d532026e91ae734&v=4",
+    rank: 1,
+    commitDays: 100,
+  },
+  {
+    username: "eddy",
+    email: "eddy@test.io",
+    avatarUrl:
+      "https://avatars0.githubusercontent.com/u/37009133?s=400&u=3998f5edfd907a527fbd8cac4d532026e91ae734&v=4",
+    rank: 2,
+    commitDays: 99,
+  },
+  {
+    username: "noel",
+    email: "noel@test.io",
+    avatarUrl:
+      "https://avatars0.githubusercontent.com/u/37009133?s=400&u=3998f5edfd907a527fbd8cac4d532026e91ae734&v=4",
+    rank: 3,
+    commitDays: 98,
+  },
+  {
+    username: "max",
+    email: "max@test.io",
+    avatarUrl:
+      "https://avatars0.githubusercontent.com/u/37009133?s=400&u=3998f5edfd907a527fbd8cac4d532026e91ae734&v=4",
+    rank: 4,
+    commitDays: 97,
+  },
+  {
+    username: "tom",
+    email: "tom@test.io",
+    avatarUrl:
+      "https://avatars0.githubusercontent.com/u/37009133?s=400&u=3998f5edfd907a527fbd8cac4d532026e91ae734&v=4",
+    rank: 5,
+    commitDays: 96,
+  },
+  {
+    username: "woo",
+    email: "woo@test.io",
+    avatarUrl:
+      "https://avatars0.githubusercontent.com/u/37009133?s=400&u=3998f5edfd907a527fbd8cac4d532026e91ae734&v=4",
+    rank: 6,
+    commitDays: 96,
+  },
+  {
+    username: "ella",
+    email: "ella@test.io",
+    avatarUrl:
+      "https://avatars0.githubusercontent.com/u/37009133?s=400&u=3998f5edfd907a527fbd8cac4d532026e91ae734&v=4",
+    rank: 7,
+    commitDays: 95,
+  },
+  {
+    username: "queen",
+    email: "queen@test.io",
+    avatarUrl:
+      "https://avatars0.githubusercontent.com/u/37009133?s=400&u=3998f5edfd907a527fbd8cac4d532026e91ae734&v=4",
+    rank: 8,
+    commitDays: 94,
+  },
+  {
+    username: "anna",
+    email: "anna@test.io",
+    avatarUrl:
+      "https://avatars0.githubusercontent.com/u/37009133?s=400&u=3998f5edfd907a527fbd8cac4d532026e91ae734&v=4",
+    rank: 9,
+    commitDays: 93,
+  },
+  {
+    username: "bill",
+    email: "bill@test.io",
+    avatarUrl:
+      "https://avatars0.githubusercontent.com/u/37009133?s=400&u=3998f5edfd907a527fbd8cac4d532026e91ae734&v=4",
+    rank: 10,
+    commitDays: 92,
+  },
+];
+
+const gap = 3;
+
+export const getRanks = (req: any, res: any) => {
+  const {
+    query: { next },
+  } = req;
+
+  if (next) {
+    // get List from DB
+    const ranks = mockupData.slice(gap * (next - 1), gap * next);
+    return res.json(ranks);
+  }
+
+  return res.status(400).send("Bad Request");
+};
+
+export const getUpdateRanks = (req: any, res: any) => {};

--- a/server/db.ts
+++ b/server/db.ts
@@ -6,7 +6,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 const url =
-  process.env.NODE_ENV === "production"
+  process.env.NODE_ENV !== "production"
     ? process.env.MONGO_URL
     : process.env.MONGO_URL_DEV;
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,14 +1,16 @@
-import globalRouter from "./routers/gloablRouter";
 import next from "next";
 import express from "express";
 import bodyParser from "body-parser";
 import cookieParser from "cookie-parser";
 import session from "express-session";
-import "./db";
-import "./passport";
 
 import dotenv from "dotenv";
 import passport from "passport";
+import routes from "./routes";
+import globalRouter from "./routers/gloablRouter";
+import apiRouter from "./routers/apiRouter";
+import "./db";
+import "./passport";
 
 dotenv.config();
 
@@ -40,6 +42,7 @@ app
     server.use(passport.session());
 
     server.use(globalRouter);
+    server.use(routes.api, apiRouter);
 
     server.get("*", (req, res) => {
       return handle(req, res);

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -5,6 +5,9 @@ export interface IUser extends mongoose.Document {
   username: string;
   avatarUrl: string;
   email: string;
+  createdAt?: Date;
+  rank?: number;
+  commitDays?: number;
 }
 
 const UserSchema = new mongoose.Schema({
@@ -12,6 +15,9 @@ const UserSchema = new mongoose.Schema({
   username: { type: String, required: true },
   avatarUrl: { type: String, required: true },
   email: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+  rank: { type: Number, default: 0 },
+  commitDays: { type: Number, default: 0 },
 });
 
 const model = mongoose.model<IUser>("User", UserSchema);

--- a/server/routers/apiRouter.ts
+++ b/server/routers/apiRouter.ts
@@ -1,0 +1,10 @@
+import * as express from "express";
+import routes from "../routes";
+import { getRanks, getUpdateRanks } from "../controllers/apiController";
+
+const apiRouter = express.Router();
+
+apiRouter.get(routes.ranks, getRanks);
+apiRouter.get(routes.updateRanks, getUpdateRanks);
+
+export default apiRouter;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,0 +1,11 @@
+const API = "/api";
+const RANKS = "/ranks";
+const UPDATE_RANKS = "/update";
+
+const routes = {
+  api: API,
+  ranks: RANKS,
+  updateRanks: UPDATE_RANKS,
+};
+
+export default routes;

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "outDir": "dist",
     "noEmit": false,
-    "baseUrl": "."
+    "baseUrl": "./"
   },
 
   "include": ["server"]


### PR DESCRIPTION
랭킹 리스트 출력하는 작업을 마쳤습니다.

처음에 화면 요청 시 리스트 내용을 api 호출을 통해서 가져와 클라이언트에게 전달합니다.
클라이언트가 스크롤을 마지막까지 내리면 api호출이 이뤄지면서 추가 랭킹을 볼 수 있습니다.

현재 맨 처음 api호출작업만 완료되었고, 스크롤 부분은 추후에 진행할 예정입니다.

그리고 이번에 사용한 데이터는 db가 아닌 그냥 테스트용 데이터를 선언해서 사용했습니다.

![image](https://user-images.githubusercontent.com/37009133/90668395-03c82000-e28b-11ea-97be-21db9c1d1f8b.png)
